### PR TITLE
Types/create document

### DIFF
--- a/src/services/firestore/createDocument/createDocument.test.ts
+++ b/src/services/firestore/createDocument/createDocument.test.ts
@@ -14,7 +14,7 @@ const TEST_DATA = {
 
 describe('createDocument function', () => {
   test('Basic usage', async () => {
-    const data = await createDocument<typeof TEST_DATA>(
+    const data = await createDocument(
       firebase.firestore(),
       TEST_COLLECTION,
       TEST_DATA
@@ -38,6 +38,7 @@ describe('createDocument function', () => {
         TEST_DATA,
         { id }
       )
+
       expect(data.id).toBe(id)
     })
   })
@@ -87,7 +88,7 @@ describe('createDocument function', () => {
 
     const testOption = (combine: string | boolean = 'id') => {
       test('TEST_DATA should be without undefined | null field, but include another falsy values.', async () => {
-        const data = await createDocument<typeof TEST_DATA>(
+        const data = await createDocument(
           firebase.firestore(),
           TEST_COLLECTION,
           TEST_DATA,
@@ -98,7 +99,7 @@ describe('createDocument function', () => {
         expect(data.avatarUrl).toBeUndefined()
       })
       test('TEST_DATA should contain all falsy values.', async () => {
-        const data = await createDocument<typeof TEST_DATA>(
+        const data = await createDocument(
           firebase.firestore(),
           TEST_COLLECTION,
           TEST_DATA,

--- a/src/services/firestore/createDocument/createDocument.test.ts
+++ b/src/services/firestore/createDocument/createDocument.test.ts
@@ -14,7 +14,7 @@ const TEST_DATA = {
 
 describe('createDocument function', () => {
   test('Basic usage', async () => {
-    const data = await createDocument<typeof TEST_DATA>(
+    const data = await createDocument<typeof TEST_DATA, any>(
       firebase.firestore(),
       TEST_COLLECTION,
       TEST_DATA
@@ -38,6 +38,7 @@ describe('createDocument function', () => {
         TEST_DATA,
         { id }
       )
+
       expect(data.id).toBe(id)
     })
   })
@@ -87,7 +88,7 @@ describe('createDocument function', () => {
 
     const testOption = (combine: string | boolean = 'id') => {
       test('TEST_DATA should be without undefined | null field, but include another falsy values.', async () => {
-        const data = await createDocument<typeof TEST_DATA>(
+        const data = await createDocument(
           firebase.firestore(),
           TEST_COLLECTION,
           TEST_DATA,
@@ -98,7 +99,7 @@ describe('createDocument function', () => {
         expect(data.avatarUrl).toBeUndefined()
       })
       test('TEST_DATA should contain all falsy values.', async () => {
-        const data = await createDocument<typeof TEST_DATA>(
+        const data = await createDocument(
           firebase.firestore(),
           TEST_COLLECTION,
           TEST_DATA,

--- a/src/services/firestore/createDocument/createDocument.ts
+++ b/src/services/firestore/createDocument/createDocument.ts
@@ -2,14 +2,15 @@ import firebase from 'firebase/app'
 import { removeUndef } from 'helpers'
 import getDocumentRef from '../getDocumentRef'
 
-type option = {
+type option<T extends string> = {
   idField?: string | undefined | null | boolean
   withoutUndef?: boolean
-  id?: string
+  id?: T
 }
-type dataType<T extends {}> = T & {
-  id: string | undefined
-}
+type dataType<P extends {}, T extends string> = Record<
+  T | keyof P | string,
+  string
+>
 /** @module @qonsoll/firebase-services/firestore */
 
 /**
@@ -30,11 +31,11 @@ type dataType<T extends {}> = T & {
  *
  * @return {Promise<object>}
  */
-const createDocument = async <T>(
+const createDocument = async <P extends {}, T extends string>(
   firestore: firebase.firestore.Firestore,
   collection: string,
-  data = {},
-  options: option = {}
+  data = <P>{},
+  options: option<T> = {}
 ) => {
   const { idField = 'id', withoutUndef = true, id } = options
 
@@ -46,7 +47,7 @@ const createDocument = async <T>(
   const docData = idField ? { ...data, [<string>idField]: docId } : data
   const normalizedData = removeUndef(withoutUndef, docData)
   await firestore.collection(collection).doc(docId).set(normalizedData)
-  return <dataType<T>>normalizedData
+  return <dataType<P, T>>normalizedData
 }
 
 export default createDocument


### PR DESCRIPTION
Updated types in createDocument function. Now you can see whole data fields in return, including custom idField.
![image](https://user-images.githubusercontent.com/88933123/140665932-4b3030aa-9fa1-432c-9bfc-fbed1193f8ad.png)
